### PR TITLE
Automaton part overlay + some bug fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ group= "io.github.moulberry"
 archivesBaseName = "NotEnoughUpdates"
 String modid = "notenoughupdates"
 String mixinClassifier = "dep"
+compileJava.options.encoding = 'UTF-8'
 
 minecraft {
     version = "1.8.9-11.15.1.2318-1.8.9"

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
@@ -836,6 +836,8 @@ public class NEUEventListener {
         if (unformatted.startsWith("You found ") && SBInfo.getInstance().getLocation() != null && SBInfo.getInstance().getLocation().equals("crystal_hollows")){
             CrystalMetalDetectorSolver.reset();
         }
+        if(unformatted.startsWith("[NPC] Professor Robot: ") || unformatted.startsWith("  "))
+            OverlayManager.automatonOverlay.message(unformatted);
     }
 
     public static boolean drawingGuiScreen = false;

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
@@ -81,7 +81,8 @@ public class CrystalMetalDetectorSolver {
     }
 
     public static void render(float partialTicks) {
-        if (SBInfo.getInstance().getLocation() != null && SBInfo.getInstance().getLocation().equals("crystal_hollows")) {
+        if (SBInfo.getInstance().getLocation() != null && SBInfo.getInstance().getLocation().equals("crystal_hollows") &&
+                SBInfo.getInstance().location.equals("Mines of Divan")) {
             if (possibleBlocks.size() == 1) {
                 RenderUtils.renderWayPoint("Treasure", possibleBlocks.get(0).add(0, 2.5, 0), partialTicks);
             } else if (possibleBlocks.size() > 1 && NotEnoughUpdates.INSTANCE.config.mining.metalDetectorShowPossible) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -85,7 +85,8 @@ public class NEUConfig extends Config {
             case 9:
                 editOverlay(activeConfigCategory, OverlayManager.bonemerangOverlay, itemOverlays.bonemerangPosition);
                 return;
-
+            case 10:
+                editOverlay(activeConfigCategory, OverlayManager.automatonOverlay, mining.automatonOverlayPosition);
         }
     }
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Mining.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Mining.java
@@ -165,6 +165,132 @@ public class Mining {
     @ConfigAccordionId(id = 3)
     public boolean metalDetectorShowPossible = false;
 
+    @ConfigOption(
+            name = "Automaton Parts Overlay",
+            desc = ""
+    )
+    @ConfigEditorAccordion(id = 4)
+    public boolean automatonOverlayAccordion = false;
+
+    @Expose
+    @ConfigOption(
+            name = "Enabled",
+            desc = "Enables the Automaton parts overlay."
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 4)
+    public boolean automatonOverlay = true;
+
+    @Expose
+    @ConfigOption(
+            name = "Position",
+            desc = "Change the position of the Automaton parts overlay."
+    )
+    @ConfigEditorButton(
+            runnableId = 10,
+            buttonText = "Edit"
+    )
+    @ConfigAccordionId(id = 4)
+    public Position automatonOverlayPosition = new Position(200, 0);
+
+    @Expose
+    @ConfigOption(
+            name = "Style",
+            desc = "Change the style of the Automaton parts overlay."
+    )
+    @ConfigEditorDropdown(
+            values = {"Background", "No Shadow", "Shadow", "Full Shadow"}
+    )
+    @ConfigAccordionId(id = 4)
+    public int automatonOverlayStyle = 0;
+
+    @Expose
+    @ConfigOption(
+            name = "Show Icons",
+            desc = "Show icons in the overlay that represent the part."
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 4)
+    public boolean automatonIcons = true;
+
+
+    @Expose
+    @ConfigOption(
+            name = "Hide Done",
+            desc = "Don't show parts you've given to Professor Robot."
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 4)
+    public boolean automatonHideDone = false;
+
+    @ConfigOption(
+            name = "Colours",
+            desc = ""
+    )
+    @ConfigEditorAccordion(id = 5)
+    @ConfigAccordionId(id = 4)
+    public boolean AutomatonColourAccordion = false;
+
+    @Expose
+    @ConfigOption(
+            name = "Part colour",
+            desc = "Change the colour of the part text."
+
+    )
+    @ConfigEditorDropdown(
+            values = {"Black", "Dark Blue", "Dark Green", "Dark Aqua", "Dark Red", "Dark Purple", "Gold", "Gray", "Dark Gray", "Blue", "Green", "Aqua", "Red", "Light Purple", "Yellow", "White"}
+    )
+    @ConfigAccordionId(id = 5)
+    public int automatonPartColor = 3;
+
+    @Expose
+    @ConfigOption(
+            name = "Ready colour",
+            desc = "Change the colour when the part is given to Professor Robot."
+
+    )
+    @ConfigEditorDropdown(
+            values = {"Black", "Dark Blue", "Dark Green", "Dark Aqua", "Dark Red", "Dark Purple", "Gold", "Gray", "Dark Gray", "Blue", "Green", "Aqua", "Red", "Light Purple", "Yellow", "White"}
+    )
+    @ConfigAccordionId(id = 5)
+    public int automatonDoneColor = 10;
+
+    @Expose
+    @ConfigOption(
+            name = "In Inventory Color",
+            desc = "Change the colour when the part is in the inventory."
+
+    )
+    @ConfigEditorDropdown(
+            values = {"Black", "Dark Blue", "Dark Green", "Dark Aqua", "Dark Red", "Dark Purple", "Gold", "Gray", "Dark Gray", "Blue", "Green", "Aqua", "Red", "Light Purple", "Yellow", "White"}
+    )
+    @ConfigAccordionId(id = 5)
+    public int automatonInventoryColor = 14;
+
+    @Expose
+    @ConfigOption(
+            name = "In Storage Color",
+            desc = "Change the colour when the part is in the storage."
+
+    )
+    @ConfigEditorDropdown(
+            values = {"Black", "Dark Blue", "Dark Green", "Dark Aqua", "Dark Red", "Dark Purple", "Gold", "Gray", "Dark Gray", "Blue", "Green", "Aqua", "Red", "Light Purple", "Yellow", "White"}
+    )
+    @ConfigAccordionId(id = 5)
+    public int automatonStorageColor = 14;
+
+    @Expose
+    @ConfigOption(
+            name = "Missing Color",
+            desc = "Change the colour when the part is missing."
+
+    )
+    @ConfigEditorDropdown(
+            values = {"Black", "Dark Blue", "Dark Green", "Dark Aqua", "Dark Red", "Dark Purple", "Gold", "Gray", "Dark Gray", "Blue", "Green", "Aqua", "Red", "Light Purple", "Yellow", "White"}
+    )
+    @ConfigAccordionId(id = 5)
+    public int automatonMissingColor = 12;
+
     @Expose
     @ConfigOption(
             name = "Puzzler Solver",

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/AutomatonOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/AutomatonOverlay.java
@@ -54,8 +54,6 @@ public class AutomatonOverlay extends TextOverlay {
             Boolean has = items.get(key);
             if (has)
                 states.put(key, EnumChatFormatting.values()[NotEnoughUpdates.INSTANCE.config.mining.automatonDoneColor] + "Done");
-            /*else
-                states.put(key, EnumChatFormatting.values()[NotEnoughUpdates.INSTANCE.config.mining.automatonMissingColor] + "Missing");*/
         }
         for (ItemStack item : mc.thePlayer.inventory.mainInventory) {
             if (item != null) {

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/AutomatonOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/AutomatonOverlay.java
@@ -1,0 +1,169 @@
+package io.github.moulberry.notenoughupdates.overlays;
+
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
+import io.github.moulberry.notenoughupdates.core.config.Position;
+import io.github.moulberry.notenoughupdates.miscfeatures.StorageManager;
+import io.github.moulberry.notenoughupdates.util.SBInfo;
+import io.github.moulberry.notenoughupdates.util.Utils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+import org.lwjgl.util.vector.Vector2f;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AutomatonOverlay extends TextOverlay {
+    private static final HashMap<String, Boolean> items;
+    private static final Minecraft mc = Minecraft.getMinecraft();
+    private final StorageManager storageManager = StorageManager.getInstance();
+    private final Pattern givePattern = Pattern.compile("\\[NPC] Professor Robot: Thanks for bringing me the (?<part>[a-zA-Z0-9 ]+)! Bring me (\\d+|one) more components? to fix the giant!");
+    private final Pattern notFinalPattern = Pattern.compile("\\[NPC] Professor Robot: That's not the final component! Bring me a (?<part>[a-zA-Z0-9 ]+) to gain access to Automaton Prime's storage container!");
+
+    static {
+        items = new HashMap<>();
+        items.put("Electron Transmitter", false);
+        items.put("FTX 3070", false);
+        items.put("Robotron Reflector", false);
+        items.put("Superlite Motor", false);
+        items.put("Control Switch", false);
+        items.put("Synthetic Heart", false);
+    }
+
+    public AutomatonOverlay(Position position, Supplier<List<String>> dummyStrings, Supplier<TextOverlayStyle> styleSupplier) {
+        super(position, dummyStrings, styleSupplier);
+    }
+
+    @Override
+    public void update() {
+        overlayStrings = null;
+        if (!NotEnoughUpdates.INSTANCE.config.mining.automatonOverlay || SBInfo.getInstance().getLocation() == null ||
+                !SBInfo.getInstance().getLocation().equals("crystal_hollows") || !SBInfo.getInstance().location.equals("Lost Precursor City"))
+            return;
+
+        overlayStrings = new ArrayList<>();
+        HashMap<String, String> states = new HashMap<>();
+        for (String key : items.keySet()) {
+            Boolean has = items.get(key);
+            if (has)
+                states.put(key, EnumChatFormatting.values()[NotEnoughUpdates.INSTANCE.config.mining.automatonDoneColor] + "Done");
+            /*else
+                states.put(key, EnumChatFormatting.values()[NotEnoughUpdates.INSTANCE.config.mining.automatonMissingColor] + "Missing");*/
+        }
+        for (ItemStack item : mc.thePlayer.inventory.mainInventory) {
+            if (item != null) {
+                String name = Utils.cleanColour(item.getDisplayName());
+                if (!states.containsKey(name)) {
+                    states.put(name, EnumChatFormatting.values()[NotEnoughUpdates.INSTANCE.config.mining.automatonInventoryColor] + "In Inventory");
+                }
+            }
+        }
+        for (Map.Entry<Integer, Integer> entry : storageManager.storageConfig.displayToStorageIdMap.entrySet()) {
+            int storageId = entry.getValue();
+            StorageManager.StoragePage page = storageManager.getPage(storageId, false);
+            if (page != null && page.rows > 0) {
+                for (ItemStack item : page.items) {
+                    if (item != null) {
+                        String name = Utils.cleanColour(item.getDisplayName());
+                        if (!states.containsKey(name)) {
+                            states.put(name, EnumChatFormatting.values()[NotEnoughUpdates.INSTANCE.config.mining.automatonStorageColor] + "In Storage");
+                        }
+                    }
+                }
+            }
+        }
+        for (String key : items.keySet()) {
+            if (!NotEnoughUpdates.INSTANCE.config.mining.automatonHideDone || !items.get(key)) {
+                if (!states.containsKey(key))
+                    states.put(key, EnumChatFormatting.values()[NotEnoughUpdates.INSTANCE.config.mining.automatonMissingColor] + "Missing");
+                overlayStrings.add(EnumChatFormatting.values()[NotEnoughUpdates.INSTANCE.config.mining.automatonPartColor] + key + ": " + states.get(key));
+            }
+        }
+    }
+
+    public void message(String message) {
+        if (message.startsWith("  ")) {
+            String item = message.replace("  ", "");
+            if (items.containsKey(item)) {
+                items.put(item, false);
+            }
+        } else if (message.startsWith("[NPC] Professor Robot: ")) {
+            if (message.equals("[NPC] Professor Robot: That's not one of the components I need! Bring me one of the missing components:")) {
+                items.replaceAll((k, v) -> true);
+            } else if (message.equals("[NPC] Professor Robot: You've brought me all of the components!")) {
+                items.replaceAll((k, v) -> false);
+            } else {
+                Matcher giveMatcher = givePattern.matcher(message);
+                Matcher notFinalMatcher = notFinalPattern.matcher(message);
+                if (giveMatcher.matches()) {
+                    String item = giveMatcher.group("part");
+                    if (items.containsKey(item)) {
+                        items.put(item, true);
+                    }
+                } else if (notFinalMatcher.matches()) {
+                    String item = notFinalMatcher.group("part");
+                    if (items.containsKey(item)) {
+                        items.replaceAll((k, v) -> true);
+                        items.put(item, false);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void renderLine(String line, Vector2f position, boolean dummy) {
+        if (!NotEnoughUpdates.INSTANCE.config.mining.automatonIcons) return;
+        GlStateManager.enableDepth();
+
+        ItemStack icon = null;
+        String cleaned = Utils.cleanColour(line);
+        String beforeColon = cleaned.split(":")[0];
+        switch (beforeColon) {
+            case "Electron Transmitter":
+                icon = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager.getItemInformation().get("ELECTRON_TRANSMITTER"));
+                break;
+            case "FTX 3070":
+                icon = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager.getItemInformation().get("FTX_3070"));
+                break;
+            case "Robotron Reflector":
+                icon = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager.getItemInformation().get("ROBOTRON_REFLECTOR"));
+                break;
+            case "Superlite Motor":
+                icon = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager.getItemInformation().get("SUPERLITE_MOTOR"));
+                break;
+            case "Control Switch":
+                icon = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager.getItemInformation().get("CONTROL_SWITCH"));
+                break;
+            case "Synthetic Heart":
+                icon = NotEnoughUpdates.INSTANCE.manager.jsonToStack(NotEnoughUpdates.INSTANCE.manager.getItemInformation().get("SYNTHETIC_HEART"));
+                break;
+        }
+
+        if (icon != null) {
+            GlStateManager.pushMatrix();
+            GlStateManager.translate(position.x - 2, position.y - 2, 0);
+            GlStateManager.scale(0.7f, 0.7f, 1f);
+            Utils.drawItemStack(icon, 0, 0);
+            GlStateManager.popMatrix();
+
+            position.x += 12;
+        }
+
+        super.renderLine(line, position, dummy);
+    }
+
+    @Override
+    protected Vector2f getSize(List<String> strings) {
+        if (NotEnoughUpdates.INSTANCE.config.mining.automatonIcons)
+            return super.getSize(strings).translate(12, 0);
+        return super.getSize(strings);
+    }
+}

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/OverlayManager.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/OverlayManager.java
@@ -16,6 +16,7 @@ public class OverlayManager {
     public static PetInfoOverlay petInfoOverlay;
     public static TimersOverlay timersOverlay;
     public static BonemerangOverlay bonemerangOverlay;
+    public static AutomatonOverlay automatonOverlay;
     public static final List<TextOverlay> textOverlays = new ArrayList<>();
 
     static {
@@ -120,13 +121,27 @@ public class OverlayManager {
             }
             return TextOverlayStyle.BACKGROUND;
         });
+        List<String> automatonOverlayDummy = Lists.newArrayList(
+                "\u00a73Electron Transmitter: \u00a7aDone",
+                "\u00a73Robotron Reflector: \u00a7eIn Storage",
+                "\u00a73Superlite Motor: \u00a7eIn Inventory",
+                "\u00a73Synthetic Hearth: \u00a7cMissing",
+                "\u00a73Control Switch: \u00a7cMissing",
+                "\u00a73FTX 3070: \u00a7cMissing");
+        automatonOverlay = new AutomatonOverlay(NotEnoughUpdates.INSTANCE.config.mining.automatonOverlayPosition, () -> automatonOverlayDummy, () -> {
+            int style = NotEnoughUpdates.INSTANCE.config.mining.automatonOverlayStyle;
+            if(style >= 0 && style < TextOverlayStyle.values().length) {
+                return TextOverlayStyle.values()[style];
+            }
+            return TextOverlayStyle.BACKGROUND;
+        });
 
 
         textOverlays.add(miningOverlay);
         textOverlays.add(farmingOverlay);
         textOverlays.add(petInfoOverlay);
         textOverlays.add(bonemerangOverlay);
-
+        textOverlays.add(automatonOverlay);
     }
 
 }

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/TimersOverlay.java
@@ -82,7 +82,9 @@ public class TimersOverlay extends TextOverlay {
 
     @Override
     protected Vector2f getSize(List<String> strings) {
-        return super.getSize(strings).translate(12, 0);
+        if(NotEnoughUpdates.INSTANCE.config.miscOverlays.todoIcons)
+            return super.getSize(strings).translate(12, 0);
+        return super.getSize(strings);
     }
 
     private static final ItemStack CAKES_ICON = new ItemStack(Items.cake);

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
@@ -198,6 +198,7 @@ public class SBInfo {
                 for (String line : lines){
                     if (line.contains("⏣")) {
                         location = Utils.cleanColour(line).replaceAll("[^A-Za-z0-9() ]", "").trim();
+                        break;
                     }
                 }
             }

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/SBInfo.java
@@ -194,7 +194,12 @@ public class SBInfo {
                         currentTimeDate = parseFormat.parse(timeSpace);
                     } catch (ParseException e) {}
                 }
-                location = Utils.cleanColour(lines.get(3)).replaceAll("[^A-Za-z0-9() ]", "").trim();
+                //Replaced with for loop because in crystal hollows with events the line it's on can shift.
+                for (String line : lines){
+                    if (line.contains("⏣")) {
+                        location = Utils.cleanColour(line).replaceAll("[^A-Za-z0-9() ]", "").trim();
+                    }
+                }
             }
             objective = null;
 


### PR DESCRIPTION
- Automaton part overlay:
Shows parts you have given
Shows parts in inventory
Shows parts in storage
Shows when part is missing
- fixed todo overlay being to long when icons off
- added UTF-8 encoding so it doesn't yell at me when it doesn't find mappings
- fixed SBInfo.location being wrong in crystal hollows due to location line shifting during events and stuff
- only show treasure waypoints when actually in mines of divan