### PR TITLE
Add toggle for disabling treecap cooldown in item durability

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/ItemCooldowns.java
@@ -65,6 +65,10 @@ public class ItemCooldowns {
     }
 
     public static long getTreecapCooldownWithPet(){
+        if (!NotEnoughUpdates.INSTANCE.config.itemOverlays.enableCooldownInItemDurability){
+            return 0;
+        }
+
         PetInfoOverlay.Pet pet = PetInfoOverlay.getCurrentPet();
         if (NotEnoughUpdates.INSTANCE.config.itemOverlays.enableMonkeyCheck && pet != null) {
             if (pet.petLevel != null &&

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ItemOverlays.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ItemOverlays.java
@@ -27,6 +27,15 @@ public class ItemOverlays {
 
     @Expose
     @ConfigOption(
+            name = "Show in Item durability",
+            desc = "Show the cooldown of the Treecapitator in the item durability"
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 0)
+    public boolean enableCooldownInItemDurability = true;
+
+    @Expose
+    @ConfigOption(
             name = "Overlay Colour",
             desc = "Change the colour of the overlay"
     )

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ItemOverlays.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/ItemOverlays.java
@@ -46,7 +46,7 @@ public class ItemOverlays {
     @Expose
     @ConfigOption(
             name = "Enable Monkey Pet Check",
-            desc = "Will check use the API to check what pet you're using\nto determine the cooldown based off of if you have monkey pet."
+            desc = "Will check using the API to check what pet you're using\nto determine the cooldown based off of if you have a monkey pet."
     )
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 0)


### PR DESCRIPTION
This adds a toggle to disable showing the remaining cooldown of the treecap in the item durability