### PR TITLE
Metal detector solver updates

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
@@ -166,7 +166,7 @@ public class NEUEventListener {
     @SubscribeEvent
     public void onWorldLoad(WorldEvent.Unload event) {
         NotEnoughUpdates.INSTANCE.saveConfig();
-        CrystalMetalDetectorSolver.reset();
+        CrystalMetalDetectorSolver.reset(false);
     }
 
     private static long notificationDisplayMillis = 0;
@@ -862,7 +862,7 @@ public class NEUEventListener {
             }
         }
         if (unformatted.startsWith("You found ") && SBInfo.getInstance().getLocation() != null && SBInfo.getInstance().getLocation().equals("crystal_hollows")){
-            CrystalMetalDetectorSolver.reset();
+            CrystalMetalDetectorSolver.reset(true);
         }
         if(unformatted.startsWith("[NPC] Keeper of ") | unformatted.startsWith("[NPC] Professor Robot: ") || unformatted.startsWith("  ") || unformatted.startsWith("✦") ||
         unformatted.equals("  You've earned a Crystal Loot Bundle!"))

--- a/src/main/java/io/github/moulberry/notenoughupdates/core/util/render/RenderUtils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/core/util/render/RenderUtils.java
@@ -1,6 +1,7 @@
 package io.github.moulberry.notenoughupdates.core.util.render;
 
 import io.github.moulberry.notenoughupdates.core.BackgroundBlur;
+import io.github.moulberry.notenoughupdates.miscfeatures.CustomItemEffects;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
@@ -13,6 +14,8 @@ import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL14;
 import org.lwjgl.util.vector.Vector3f;
@@ -146,9 +149,111 @@ public class RenderUtils {
         GlStateManager.enableTexture2D();
     }
 
+    public static BlockPos getCurrentViewer(float partialTicks) {
+        double viewerX;
+        double viewerY;
+        double viewerZ;
+
+        Vector3f aoteInterpPos = CustomItemEffects.INSTANCE.getCurrentPosition();
+        if(aoteInterpPos != null) {
+            viewerX = aoteInterpPos.x;
+            viewerY = aoteInterpPos.y;
+            viewerZ = aoteInterpPos.z;
+        } else {
+            Entity viewer = Minecraft.getMinecraft().getRenderViewEntity();
+            viewerX = viewer.lastTickPosX + (viewer.posX - viewer.lastTickPosX) * partialTicks;
+            viewerY = viewer.lastTickPosY + (viewer.posY - viewer.lastTickPosY) * partialTicks;
+            viewerZ = viewer.lastTickPosZ + (viewer.posZ - viewer.lastTickPosZ) * partialTicks;
+        }
+
+        return new BlockPos(viewerX, viewerY, viewerZ);
+    }
+
+    private static final ResourceLocation beaconBeam = new ResourceLocation("textures/entity/beacon_beam.png");
+
+    public static void renderBeaconBeam(double x, double y, double z, int rgb, float alphaMult, float partialTicks) {
+        int height = 300;
+        int bottomOffset = 0;
+        int topOffset = bottomOffset + height;
+
+        Tessellator tessellator = Tessellator.getInstance();
+        WorldRenderer worldrenderer = tessellator.getWorldRenderer();
+
+        Minecraft.getMinecraft().getTextureManager().bindTexture(beaconBeam);
+
+        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL11.GL_REPEAT);
+        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL11.GL_REPEAT);
+        GlStateManager.disableLighting();
+        GlStateManager.enableCull();
+        GlStateManager.enableTexture2D();
+        GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE, GL11.GL_ZERO);
+        GlStateManager.enableBlend();
+        GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
+
+        double time = Minecraft.getMinecraft().theWorld.getTotalWorldTime() + (double)partialTicks;
+        double d1 = MathHelper.func_181162_h(-time * 0.2D - (double)MathHelper.floor_double(-time * 0.1D));
+
+        float r = ((rgb >> 16) & 0xFF) / 255f;
+        float g = ((rgb >> 8) & 0xFF) / 255f;
+        float b = (rgb & 0xFF) / 255f;
+        double d2 = time * 0.025D * -1.5D;
+        double d4 = 0.5D + Math.cos(d2 + 2.356194490192345D) * 0.2D;
+        double d5 = 0.5D + Math.sin(d2 + 2.356194490192345D) * 0.2D;
+        double d6 = 0.5D + Math.cos(d2 + (Math.PI / 4D)) * 0.2D;
+        double d7 = 0.5D + Math.sin(d2 + (Math.PI / 4D)) * 0.2D;
+        double d8 = 0.5D + Math.cos(d2 + 3.9269908169872414D) * 0.2D;
+        double d9 = 0.5D + Math.sin(d2 + 3.9269908169872414D) * 0.2D;
+        double d10 = 0.5D + Math.cos(d2 + 5.497787143782138D) * 0.2D;
+        double d11 = 0.5D + Math.sin(d2 + 5.497787143782138D) * 0.2D;
+        double d14 = -1.0D + d1;
+        double d15 = (double)(height) * 2.5D + d14;
+        worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+        worldrenderer.pos(x + d4, y + topOffset, z + d5).tex(1.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
+        worldrenderer.pos(x + d4, y + bottomOffset, z + d5).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d6, y + bottomOffset, z + d7).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d6, y + topOffset, z + d7).tex(0.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
+        worldrenderer.pos(x + d10, y + topOffset, z + d11).tex(1.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
+        worldrenderer.pos(x + d10, y + bottomOffset, z + d11).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d8, y + bottomOffset, z + d9).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d8, y + topOffset, z + d9).tex(0.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
+        worldrenderer.pos(x + d6, y + topOffset, z + d7).tex(1.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
+        worldrenderer.pos(x + d6, y + bottomOffset, z + d7).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d10, y + bottomOffset, z + d11).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d10, y + topOffset, z + d11).tex(0.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
+        worldrenderer.pos(x + d8, y + topOffset, z + d9).tex(1.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
+        worldrenderer.pos(x + d8, y + bottomOffset, z + d9).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d4, y + bottomOffset, z + d5).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d4, y + topOffset, z + d5).tex(0.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
+        tessellator.draw();
+
+        GlStateManager.disableCull();
+        double d12 = -1.0D + d1;
+        double d13 = height + d12;
+
+        worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.2D).tex(1.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
+        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.2D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.2D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.2D).tex(0.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
+        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.8D).tex(1.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
+        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.8D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.8D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.8D).tex(0.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
+        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.2D).tex(1.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
+        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.2D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.8D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.8D).tex(0.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
+        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.8D).tex(1.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
+        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.8D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.2D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.2D).tex(0.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
+        tessellator.draw();
+    }
+
     public static void renderWayPoint(String str, BlockPos loc, float partialTicks) {
         renderWayPoint(str, new Vector3f(loc.getX(), loc.getY(), loc.getZ()), partialTicks);
     }
+
     public static void renderWayPoint(String str, Vector3f loc, float partialTicks) {
         GlStateManager.alphaFunc(516, 0.1F);
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
@@ -118,7 +118,8 @@ public class CrystalMetalDetectorSolver {
 
                 RenderUtils.renderBeaconBeam(x, y, z, beaconRGB, 1.0f, partialTicks);
                 RenderUtils.renderWayPoint("Treasure", possibleBlocks.get(0).add(0, 2.5, 0), partialTicks);
-            } else if (possibleBlocks.size() > 1 && NotEnoughUpdates.INSTANCE.config.mining.metalDetectorShowPossible) {
+            } else if (possibleBlocks.size() > 1 && (locations.size() > 1 || possibleBlocks.size() < 10) &&
+                    NotEnoughUpdates.INSTANCE.config.mining.metalDetectorShowPossible) {
                 for (BlockPos block : possibleBlocks) {
                     double x = block.getX() - viewer.getX();
                     double y = block.getY() - viewer.getY();;
@@ -137,7 +138,7 @@ public class CrystalMetalDetectorSolver {
     }
 
     private static void removeDuplicates() {
-        if (possibleBlocks.size() > 1 && possibleBlocks.size() < 7) {
+        if (possibleBlocks.size() > 1 && possibleBlocks.size() < 10) {
             Vec3 firstBlockVec = new Vec3( possibleBlocks.get(0).getX(), 0,  possibleBlocks.get(0).getZ());
             Boolean allBlocksAreClose = true;
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
@@ -11,82 +11,106 @@ import java.util.List;
 
 public class CrystalMetalDetectorSolver {
     private static final Minecraft mc = Minecraft.getMinecraft();
-    private static BlockPos prevPos;
-    private static double prevDist = 0;
+    private static BlockPos prevPlayerPos;
+    private static double prevDistToTreasure = 0;
     private static List<BlockPos> possibleBlocks = new ArrayList<>();
     private static final List<BlockPos> locations = new ArrayList<>();
 
     public static void process(IChatComponent message) {
         if (SBInfo.getInstance().getLocation() != null && SBInfo.getInstance().getLocation().equals("crystal_hollows")
                 && message.getUnformattedText().contains("TREASURE: ")) {
-            double dist = Double.parseDouble(message.getUnformattedText().split("TREASURE: ")[1].split("m")[0].replaceAll("(?!\\.)\\D", ""));
-            if (NotEnoughUpdates.INSTANCE.config.mining.metalDetectorEnabled && prevDist == dist && prevPos.getX() == mc.thePlayer.getPosition().getX() &&
-                    prevPos.getY() == mc.thePlayer.getPosition().getY() &&
-                    prevPos.getZ() == mc.thePlayer.getPosition().getZ() && !locations.contains(mc.thePlayer.getPosition())) {
+            double distToTreasure = Double.parseDouble(message.getUnformattedText().split("TREASURE: ")[1].split("m")[0].replaceAll("(?!\\.)\\D", ""));
+            if (NotEnoughUpdates.INSTANCE.config.mining.metalDetectorEnabled && prevDistToTreasure == distToTreasure &&
+                    prevPlayerPos.getX() == mc.thePlayer.getPosition().getX() &&
+                    prevPlayerPos.getY() == mc.thePlayer.getPosition().getY() &&
+                    prevPlayerPos.getZ() == mc.thePlayer.getPosition().getZ() && !locations.contains(mc.thePlayer.getPosition())) {
                 if (possibleBlocks.size() == 0) {
                     locations.add(mc.thePlayer.getPosition());
-                    for (int zOffset = (int) Math.floor(-dist); zOffset <= Math.ceil(dist); zOffset++) {
+                    for (int zOffset = (int) Math.floor(-distToTreasure); zOffset <= Math.ceil(distToTreasure); zOffset++) {
                         for (int y = 65; y <= 75; y++) {
                             double calculatedDist = 0;
                             int xOffset = 0;
-                            while (calculatedDist < dist) {
+                            while (calculatedDist < distToTreasure) {
                                 BlockPos pos = new BlockPos(Math.floor(mc.thePlayer.posX) + xOffset,
                                         y, Math.floor(mc.thePlayer.posZ) + zOffset);
-                                BlockPos above = new BlockPos(Math.floor(mc.thePlayer.posX) + xOffset,
-                                        y + 1, Math.floor(mc.thePlayer.posZ) + zOffset);
                                 calculatedDist = getPlayerPos().distanceTo(new Vec3(pos).addVector(0D, 1D, 0D));
-                                if (round(calculatedDist, 1) == dist && treasureAllowed(pos) && !possibleBlocks.contains(pos) &&
-                                        mc.theWorld.getBlockState(above).getBlock().getRegistryName().equals("minecraft:air")) {
+                                if (round(calculatedDist, 1) == distToTreasure && !possibleBlocks.contains(pos)) {
                                     possibleBlocks.add(pos);
                                 }
                                 xOffset++;
                             }
                             xOffset = 0;
                             calculatedDist = 0;
-                            while (calculatedDist < dist) {
+                            while (calculatedDist < distToTreasure) {
                                 BlockPos pos = new BlockPos(Math.floor(mc.thePlayer.posX) - xOffset,
                                         y, Math.floor(mc.thePlayer.posZ) + zOffset);
-                                BlockPos above = new BlockPos(Math.floor(mc.thePlayer.posX) - xOffset,
-                                        y + 1, Math.floor(mc.thePlayer.posZ) + zOffset);
                                 calculatedDist = getPlayerPos().distanceTo(new Vec3(pos).addVector(0D, 1D, 0D));
-                                if (round(calculatedDist, 1) == dist && treasureAllowed(pos) && !possibleBlocks.contains(pos) &&
-                                        mc.theWorld.getBlockState(above).getBlock().getRegistryName().equals("minecraft:air")) {
+                                if (round(calculatedDist, 1) == distToTreasure && !possibleBlocks.contains(pos)) {
                                     possibleBlocks.add(pos);
                                 }
                                 xOffset++;
                             }
                         }
                     }
+                    removeDuplicates();
                     sendMessage();
                 } else if (possibleBlocks.size() != 1) {
                     locations.add(mc.thePlayer.getPosition());
                     List<BlockPos> temp = new ArrayList<>();
                     for (BlockPos pos : possibleBlocks) {
-                        if (round(getPlayerPos().distanceTo(new Vec3(pos).addVector(0D, 1D, 0D)), 1) == dist) {
+                        if (round(getPlayerPos().distanceTo(new Vec3(pos).addVector(0D, 1D, 0D)), 1) == distToTreasure) {
                             temp.add(pos);
                         }
                     }
                     possibleBlocks = temp;
+                    removeDuplicates();
                     sendMessage();
+                } else if (possibleBlocks.size() == 1) {
+                    BlockPos pos =  possibleBlocks.get(0);
+                    if (distToTreasure > (5 + getPlayerPos().distanceTo(new Vec3(pos)))) {
+                        mc.thePlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "[NEU] Previous solution is invalid."));
+                        reset(false);
+                    }
                 }
+
             }
-            prevPos = mc.thePlayer.getPosition();
-            prevDist = dist;
+
+            prevPlayerPos = mc.thePlayer.getPosition();
+            prevDistToTreasure = distToTreasure;
         }
     }
 
-    public static void reset() {
+    public static void reset(Boolean chestFound) {
+        if (chestFound) {
+            // TODO: Add a delay to keep the old chest location from being treated as the new chest location
+        }
+
         possibleBlocks.clear();
         locations.clear();
     }
 
     public static void render(float partialTicks) {
+        int beaconRGB = 0xa839ce;
+
         if (SBInfo.getInstance().getLocation() != null && SBInfo.getInstance().getLocation().equals("crystal_hollows") &&
                 SBInfo.getInstance().location.equals("Mines of Divan")) {
+            BlockPos viewer = RenderUtils.getCurrentViewer(partialTicks);
+
             if (possibleBlocks.size() == 1) {
+                BlockPos block = possibleBlocks.get(0);
+                double x = block.getX() - viewer.getX();
+                double y = block.getY() - viewer.getY();
+                double z = block.getZ() - viewer.getZ();
+
+                RenderUtils.renderBeaconBeam(x, y, z, beaconRGB, 1.0f, partialTicks);
                 RenderUtils.renderWayPoint("Treasure", possibleBlocks.get(0).add(0, 2.5, 0), partialTicks);
             } else if (possibleBlocks.size() > 1 && NotEnoughUpdates.INSTANCE.config.mining.metalDetectorShowPossible) {
                 for (BlockPos block : possibleBlocks) {
+                    double x = block.getX() - viewer.getX();
+                    double y = block.getY() - viewer.getY();;
+                    double z = block.getZ() - viewer.getZ();;
+
+                    RenderUtils.renderBeaconBeam(x, y, z, beaconRGB, 1.0f, partialTicks);
                     RenderUtils.renderWayPoint("Possible Treasure Location", block.add(0, 2.5, 0), partialTicks);
                 }
             }
@@ -98,14 +122,34 @@ public class CrystalMetalDetectorSolver {
         return (double) Math.round(value * scale) / scale;
     }
 
-    private static boolean treasureAllowed(BlockPos pos) {
-        return mc.theWorld.getBlockState(pos).getBlock().getRegistryName().equals("minecraft:gold_block") ||
-                mc.theWorld.getBlockState(pos).getBlock().getRegistryName().equals("minecraft:prismarine") ||
-                mc.theWorld.getBlockState(pos).getBlock().getRegistryName().equals("minecraft:chest") ||
-                mc.theWorld.getBlockState(pos).getBlock().getRegistryName().equals("minecraft:stained_glass") ||
-                mc.theWorld.getBlockState(pos).getBlock().getRegistryName().equals("minecraft:stained_glass_pane") ||
-                mc.theWorld.getBlockState(pos).getBlock().getRegistryName().equals("minecraft:wool") ||
-                mc.theWorld.getBlockState(pos).getBlock().getRegistryName().equals("minecraft:stained_hardened_clay");
+    private static void removeDuplicates() {
+        if (possibleBlocks.size() > 1 && possibleBlocks.size() < 7) {
+            double firstX = possibleBlocks.get(0).getX();
+            double firstZ = possibleBlocks.get(0).getZ();
+            Boolean yOnlyDiffers = true;
+
+            double lowestY = possibleBlocks.get(0).getY();
+            int lowestYIndex = 0;
+
+            for (int i = 1; i < possibleBlocks.size(); i++) {
+                BlockPos block = possibleBlocks.get(i);
+                if (block.getX() != firstX || block.getZ() != firstZ) {
+                    yOnlyDiffers = false;
+                    break;
+                }
+
+                if (block.getY() < lowestY) {
+                    lowestY = block.getY();
+                    lowestYIndex = i;
+                }
+            }
+
+            if (yOnlyDiffers) {
+                List<BlockPos> temp = new ArrayList<>();
+                temp.add(possibleBlocks.get(lowestYIndex));
+                possibleBlocks = temp;
+            }
+        }
     }
 
     private static void sendMessage() {
@@ -114,7 +158,7 @@ public class CrystalMetalDetectorSolver {
                     + possibleBlocks.size()));
         } else if (possibleBlocks.size() == 0) {
             mc.thePlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "[NEU] Failed to find solution."));
-            reset();
+            reset(false);
         } else {
             mc.thePlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.YELLOW + "[NEU] Found solution."));
         }

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/CrystalMetalDetectorSolver.java
@@ -108,24 +108,16 @@ public class CrystalMetalDetectorSolver {
 
         if (SBInfo.getInstance().getLocation() != null && SBInfo.getInstance().getLocation().equals("crystal_hollows") &&
                 SBInfo.getInstance().location.equals("Mines of Divan")) {
-            BlockPos viewer = RenderUtils.getCurrentViewer(partialTicks);
 
             if (possibleBlocks.size() == 1) {
                 BlockPos block = possibleBlocks.get(0);
-                double x = block.getX() - viewer.getX();
-                double y = block.getY() - viewer.getY();
-                double z = block.getZ() - viewer.getZ();
 
-                RenderUtils.renderBeaconBeam(x, y, z, beaconRGB, 1.0f, partialTicks);
+                RenderUtils.renderBeaconBeam(block, beaconRGB, 1.0f, partialTicks);
                 RenderUtils.renderWayPoint("Treasure", possibleBlocks.get(0).add(0, 2.5, 0), partialTicks);
             } else if (possibleBlocks.size() > 1 && (locations.size() > 1 || possibleBlocks.size() < 10) &&
                     NotEnoughUpdates.INSTANCE.config.mining.metalDetectorShowPossible) {
                 for (BlockPos block : possibleBlocks) {
-                    double x = block.getX() - viewer.getX();
-                    double y = block.getY() - viewer.getY();;
-                    double z = block.getZ() - viewer.getZ();;
-
-                    RenderUtils.renderBeaconBeam(x, y, z, beaconRGB, 1.0f, partialTicks);
+                    RenderUtils.renderBeaconBeam(block, beaconRGB, 1.0f, partialTicks);
                     RenderUtils.renderWayPoint("Possible Treasure Location", block.add(0, 2.5, 0), partialTicks);
                 }
             }

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.commands.SimpleCommand;
+import io.github.moulberry.notenoughupdates.core.util.render.RenderUtils;
 import io.github.moulberry.notenoughupdates.options.NEUConfig;
 import io.github.moulberry.notenoughupdates.util.Constants;
 import io.github.moulberry.notenoughupdates.util.SBInfo;
@@ -166,86 +167,6 @@ public class FairySouls {
         }
     }
 
-    private static final ResourceLocation beaconBeam = new ResourceLocation("textures/entity/beacon_beam.png");
-
-    private static void renderBeaconBeam(double x, double y, double z, int rgb, float alphaMult, float partialTicks) {
-        int height = 300;
-        int bottomOffset = 0;
-        int topOffset = bottomOffset + height;
-
-        Tessellator tessellator = Tessellator.getInstance();
-        WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-
-        Minecraft.getMinecraft().getTextureManager().bindTexture(beaconBeam);
-        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, 10497.0F);
-        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, 10497.0F);
-        GlStateManager.disableLighting();
-        GlStateManager.enableCull();
-        GlStateManager.enableTexture2D();
-        GlStateManager.tryBlendFuncSeparate(770, 1, 1, 0);
-        GlStateManager.enableBlend();
-        GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
-
-        double time = Minecraft.getMinecraft().theWorld.getTotalWorldTime() + (double)partialTicks;
-        double d1 = MathHelper.func_181162_h(-time * 0.2D - (double)MathHelper.floor_double(-time * 0.1D));
-
-        float r = ((rgb >> 16) & 0xFF) / 255f;
-        float g = ((rgb >> 8) & 0xFF) / 255f;
-        float b = (rgb & 0xFF) / 255f;
-        double d2 = time * 0.025D * -1.5D;
-        double d4 = 0.5D + Math.cos(d2 + 2.356194490192345D) * 0.2D;
-        double d5 = 0.5D + Math.sin(d2 + 2.356194490192345D) * 0.2D;
-        double d6 = 0.5D + Math.cos(d2 + (Math.PI / 4D)) * 0.2D;
-        double d7 = 0.5D + Math.sin(d2 + (Math.PI / 4D)) * 0.2D;
-        double d8 = 0.5D + Math.cos(d2 + 3.9269908169872414D) * 0.2D;
-        double d9 = 0.5D + Math.sin(d2 + 3.9269908169872414D) * 0.2D;
-        double d10 = 0.5D + Math.cos(d2 + 5.497787143782138D) * 0.2D;
-        double d11 = 0.5D + Math.sin(d2 + 5.497787143782138D) * 0.2D;
-        double d14 = -1.0D + d1;
-        double d15 = (double)(height) * 2.5D + d14;
-        worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
-        worldrenderer.pos(x + d4, y + topOffset, z + d5).tex(1.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
-        worldrenderer.pos(x + d4, y + bottomOffset, z + d5).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
-        worldrenderer.pos(x + d6, y + bottomOffset, z + d7).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
-        worldrenderer.pos(x + d6, y + topOffset, z + d7).tex(0.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
-        worldrenderer.pos(x + d10, y + topOffset, z + d11).tex(1.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
-        worldrenderer.pos(x + d10, y + bottomOffset, z + d11).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
-        worldrenderer.pos(x + d8, y + bottomOffset, z + d9).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
-        worldrenderer.pos(x + d8, y + topOffset, z + d9).tex(0.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
-        worldrenderer.pos(x + d6, y + topOffset, z + d7).tex(1.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
-        worldrenderer.pos(x + d6, y + bottomOffset, z + d7).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
-        worldrenderer.pos(x + d10, y + bottomOffset, z + d11).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
-        worldrenderer.pos(x + d10, y + topOffset, z + d11).tex(0.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
-        worldrenderer.pos(x + d8, y + topOffset, z + d9).tex(1.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
-        worldrenderer.pos(x + d8, y + bottomOffset, z + d9).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
-        worldrenderer.pos(x + d4, y + bottomOffset, z + d5).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
-        worldrenderer.pos(x + d4, y + topOffset, z + d5).tex(0.0D, d15).color(r, g, b, 1.0F*alphaMult).endVertex();
-        tessellator.draw();
-
-        GlStateManager.disableCull();
-        double d12 = -1.0D + d1;
-        double d13 = height + d12;
-
-        worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
-        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.2D).tex(1.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
-        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.2D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
-        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.2D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
-        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.2D).tex(0.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
-        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.8D).tex(1.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
-        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.8D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
-        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.8D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
-        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.8D).tex(0.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
-        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.2D).tex(1.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
-        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.2D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
-        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.8D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
-        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.8D).tex(0.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
-        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.8D).tex(1.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
-        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.8D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
-        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.2D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
-        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.2D).tex(0.0D, d13).color(r, g, b, 0.25F*alphaMult).endVertex();
-        tessellator.draw();
-    }
-
     @SubscribeEvent
     public void onRenderLast(RenderWorldLastEvent event) {
         if(!enabled) return;
@@ -254,26 +175,16 @@ public class FairySouls {
         if(location == null) return;
         if(currentSoulList == null || currentSoulList.isEmpty()) return;
 
-        Entity viewer = Minecraft.getMinecraft().getRenderViewEntity();
-        double viewerX = viewer.lastTickPosX + (viewer.posX - viewer.lastTickPosX) * event.partialTicks;
-        double viewerY = viewer.lastTickPosY + (viewer.posY - viewer.lastTickPosY) * event.partialTicks;
-        double viewerZ = viewer.lastTickPosZ + (viewer.posZ - viewer.lastTickPosZ) * event.partialTicks;
-
-        Vector3f aoteInterpPos = CustomItemEffects.INSTANCE.getCurrentPosition();
-        if(aoteInterpPos != null) {
-            viewerX = aoteInterpPos.x;
-            viewerY = aoteInterpPos.y;
-            viewerZ = aoteInterpPos.z;
-        }
-
         Set<Integer> found = foundSouls.computeIfAbsent(location, k -> new HashSet<>());
+
+        BlockPos viewer = RenderUtils.getCurrentViewer(event.partialTicks);
 
         int rgb = 0xa839ce;
         for(int i=0; i<currentSoulListClose.size(); i++) {
             BlockPos currentSoul = currentSoulListClose.get(i);
-            double x = currentSoul.getX() - viewerX;
-            double y = currentSoul.getY() - viewerY;
-            double z = currentSoul.getZ() - viewerZ;
+            double x = currentSoul.getX() - viewer.getX();
+            double y = currentSoul.getY() - viewer.getY();
+            double z = currentSoul.getZ() - viewer.getZ();
 
             double distSq = x*x + y*y + z*z;
 
@@ -285,7 +196,7 @@ public class FairySouls {
             CustomItemEffects.drawFilledBoundingBox(bb, 1f, SpecialColour.special(0, 100, rgb));
 
             if(distSq > 10*10) {
-                renderBeaconBeam(x, y, z, rgb, 1.0f, event.partialTicks);
+                RenderUtils.renderBeaconBeam(x, y, z, rgb, 1.0f, event.partialTicks);
             }
         }
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/FairySouls.java
@@ -6,26 +6,17 @@ import com.google.gson.JsonObject;
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates;
 import io.github.moulberry.notenoughupdates.commands.SimpleCommand;
 import io.github.moulberry.notenoughupdates.core.util.render.RenderUtils;
-import io.github.moulberry.notenoughupdates.options.NEUConfig;
 import io.github.moulberry.notenoughupdates.util.Constants;
 import io.github.moulberry.notenoughupdates.util.SBInfo;
 import io.github.moulberry.notenoughupdates.util.SpecialColour;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.WorldRenderer;
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.command.ICommandSender;
-import net.minecraft.entity.Entity;
 import net.minecraft.util.*;
-import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent;
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.util.vector.Vector3f;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -177,32 +168,11 @@ public class FairySouls {
 
         Set<Integer> found = foundSouls.computeIfAbsent(location, k -> new HashSet<>());
 
-        BlockPos viewer = RenderUtils.getCurrentViewer(event.partialTicks);
-
         int rgb = 0xa839ce;
         for(int i=0; i<currentSoulListClose.size(); i++) {
             BlockPos currentSoul = currentSoulListClose.get(i);
-            double x = currentSoul.getX() - viewer.getX();
-            double y = currentSoul.getY() - viewer.getY();
-            double z = currentSoul.getZ() - viewer.getZ();
-
-            double distSq = x*x + y*y + z*z;
-
-            AxisAlignedBB bb = new AxisAlignedBB(x, y, z, x+1, y+1, z+1);
-
-            GlStateManager.disableDepth();
-            GlStateManager.disableCull();
-            GlStateManager.disableTexture2D();
-            CustomItemEffects.drawFilledBoundingBox(bb, 1f, SpecialColour.special(0, 100, rgb));
-
-            if(distSq > 10*10) {
-                RenderUtils.renderBeaconBeam(x, y, z, rgb, 1.0f, event.partialTicks);
-            }
+            RenderUtils.renderBeaconBeamOrBoundingBox(currentSoul, rgb, 1.0f, event.partialTicks);
         }
-
-        GlStateManager.disableLighting();
-        GlStateManager.enableTexture2D();
-        GlStateManager.enableDepth();
     }
 
     public static class FairySoulsCommandAlt extends SimpleCommand {


### PR DESCRIPTION
- Move beacon beam rendering related code into RenderUtils

- Show beacons and labels for metal detector locations

- Replace code that Hypixel would likely ban as X-Ray with code based on eliminating duplicate Y values. The number of unique locations for the new code to work is still 2-3, but results in odd locations being treated as valid (mid-air, outside Mines, blocks not exposed to air). This could be made better by detecting the NPCs coordinates to filter  valid coordinates.

- Add a delay after a chest is found to allow the distance status to update from the server. This avoids the old chest location being incorrectly used as the solution for the new chest.

- Add detection for the previous solution being incorrect - which, while rare with the previous change, does happen.