### PR TITLE
Introduce location specific config, move commission maxes into it

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/NEUConfig.java
@@ -264,6 +264,8 @@ public class NEUConfig extends Config {
     public static class Hidden {
         @Expose
         public HashMap<String, NEUConfig.HiddenProfileSpecific> profileSpecific = new HashMap<>();
+        @Expose
+        public HashMap<String, NEUConfig.HiddenLocationSpecific> locationSpecific = new HashMap<>();
         @Expose public List<NEUConfig.InventoryButton> inventoryButtons = createDefaultInventoryButtons();
 
         @Expose public boolean enableItemEditing = false;
@@ -284,7 +286,6 @@ public class NEUConfig extends Config {
         @Expose public ArrayList<String> enchantColours = createDefaultEnchantColours();
         @Expose public String repoURL = "https://github.com/Moulberry/NotEnoughUpdates-REPO/archive/master.zip";
         @Expose public String repoCommitsURL = "https://api.github.com/repos/Moulberry/NotEnoughUpdates-REPO/commits/master";
-        @Expose public Map<String, Integer> commissionMaxes = new HashMap<>();
 
         @Expose public boolean firstTimeSearchFocus = true;
 
@@ -361,9 +362,20 @@ public class NEUConfig extends Config {
             put("Sapphire", 0);
             put("Topaz", 0);
         }};
-    }
+      }
 
-    public static List<InventoryButton> createDefaultInventoryButtons() {
+      public HiddenLocationSpecific getLocationSpecific() {
+            if(SBInfo.getInstance().location == null) {
+                return null;
+            }
+            return hidden.locationSpecific.computeIfAbsent(SBInfo.getInstance().getLocation(), k-> new HiddenLocationSpecific());
+        }
+
+        public static class HiddenLocationSpecific {
+            @Expose public Map<String, Integer> commissionMaxes = new HashMap<>();
+        }
+
+        public static List<InventoryButton> createDefaultInventoryButtons() {
         List<InventoryButton> buttons = new ArrayList<>();
         //Below crafting
         buttons.add(new InventoryButton(87, 63, null, true, false, false, 0, ""));

--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/MiningOverlay.java
@@ -79,8 +79,10 @@ public class MiningOverlay extends TextOverlay {
                                 }
                             }
                         }
+
+                        NEUConfig.HiddenLocationSpecific locationSpecific = NotEnoughUpdates.INSTANCE.config.getLocationSpecific();
                         if(name != null && numberValue > 0) {
-                            NotEnoughUpdates.INSTANCE.config.hidden.commissionMaxes.put(name, numberValue);
+                            locationSpecific.commissionMaxes.put(name, numberValue);
                         }
                     }
                 }
@@ -237,12 +239,13 @@ public class MiningOverlay extends TextOverlay {
                 String name = Minecraft.getMinecraft().ingameGUI.getTabList().getPlayerName(info);
                 if (name.contains("Mithril Powder:")) {
                     mithrilPowder = DARK_AQUA + Utils.trimIgnoreColour(name).replaceAll("\u00a7[f|F|r]", "");
+                    continue;
                 }
                 if (name.contains("Gemstone Powder:")) {
                     gemstonePowder = DARK_AQUA + Utils.trimIgnoreColour(name).replaceAll("\u00a7[f|F|r]", "");
+                    continue;
                 }
 
-                
                 if (name.matches("\\xa7r\\xa79\\xa7lForges \\xa7r(?:\\xa7f\\(\\+1 more\\)\\xa7r)?")) {
                     commissions = false;
                     forges = true;
@@ -343,8 +346,9 @@ public class MiningOverlay extends TextOverlay {
                     } else if (entry.getValue() >= 0.25) {
                         col = GOLD;
                     }
-                    if (NotEnoughUpdates.INSTANCE.config.hidden.commissionMaxes.containsKey(entry.getKey())) {
-                        int max = NotEnoughUpdates.INSTANCE.config.hidden.commissionMaxes.get(entry.getKey());
+                    NEUConfig.HiddenLocationSpecific locationSpecific = NotEnoughUpdates.INSTANCE.config.getLocationSpecific();
+                    int max;
+                    if (-1 != (max = locationSpecific.commissionMaxes.getOrDefault(entry.getKey(), -1))) {
                         commissionsStrings.add(DARK_AQUA + entry.getKey() + ": " + col + Math.round(entry.getValue() * max) + "/" + max);
                     } else {
                         String valS = Utils.floatToString(entry.getValue() * 100, 1);


### PR DESCRIPTION
Goblin Slayer commission progress doesn't show up properly since the max is 13 in the Crystal Hollows and 100 in the Dwarven Mines. This change introduces a location-specific section in the configuration and stores the commission max values there instead. 