### PR TITLE
add option to hide waypoints if already at the location

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/DwarvenMinesWaypoints.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/DwarvenMinesWaypoints.java
@@ -8,13 +8,7 @@ import io.github.moulberry.notenoughupdates.util.SBInfo;
 import io.github.moulberry.notenoughupdates.util.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
-import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiChest;
-import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.WorldRenderer;
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.inventory.ContainerChest;
 import net.minecraft.inventory.IInventory;
@@ -25,7 +19,6 @@ import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
-import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.vector.Vector3f;
 
 import java.util.HashMap;
@@ -189,32 +182,35 @@ public class DwarvenMinesWaypoints {
 
     @SubscribeEvent
     public void onRenderLast(RenderWorldLastEvent event) {
-        if(SBInfo.getInstance().getLocation() == null) return;
-        if(!SBInfo.getInstance().getLocation().equals("mining_3")) return;
+        if (SBInfo.getInstance().getLocation() == null) return;
+        if (!SBInfo.getInstance().getLocation().equals("mining_3")) return;
 
         int locWaypoint = NotEnoughUpdates.INSTANCE.config.mining.locWaypoints;
-
-        if(dynamicLocation != null && dynamicName != null &&
-                System.currentTimeMillis() - dynamicMillis < 30*1000) {
-            for(Map.Entry<String, Vector3f> entry : waypointsMap.entrySet()) {
-                if(entry.getKey().equals(dynamicLocation)) {
+        if (dynamicLocation != null && dynamicName != null &&
+                System.currentTimeMillis() - dynamicMillis < 30 * 1000) {
+            for (Map.Entry<String, Vector3f> entry : waypointsMap.entrySet()) {
+                if (entry.getKey().equals(dynamicLocation)) {
                     RenderUtils.renderWayPoint(dynamicName, new Vector3f(entry.getValue()).translate(0, 15, 0), event.partialTicks);
                     break;
                 }
             }
         }
-
-        if(locWaypoint >= 1) {
-            for(Map.Entry<String, Vector3f> entry : waypointsMap.entrySet()) {
-                if(locWaypoint >= 2) {
-                    RenderUtils.renderWayPoint(EnumChatFormatting.AQUA+entry.getKey(), entry.getValue(), event.partialTicks);
+        String skyblockLocation = SBInfo.getInstance().location.toLowerCase();
+        if (locWaypoint >= 1) {
+            for (Map.Entry<String, Vector3f> entry : waypointsMap.entrySet()) {
+                if (locWaypoint >= 2) {
+                    RenderUtils.renderWayPoint(EnumChatFormatting.AQUA + entry.getKey(), entry.getValue(), event.partialTicks);
                 } else {
-                    for(String commissionName : MiningOverlay.commissionProgress.keySet()) {
-                        if(commissionName.toLowerCase().contains(entry.getKey().toLowerCase())) {
-                            if(commissionName.contains("Titanium")) {
-                                RenderUtils.renderWayPoint(EnumChatFormatting.WHITE+entry.getKey(), entry.getValue(), event.partialTicks);
+                    String commissionLocation = entry.getKey().toLowerCase();
+                    for (String commissionName : MiningOverlay.commissionProgress.keySet()) {
+                        if (NotEnoughUpdates.INSTANCE.config.mining.hideWaypointIfAtLocation)
+                            if (commissionLocation.equals(skyblockLocation)) break;
+
+                        if (commissionName.toLowerCase().contains(commissionLocation)) {
+                            if (commissionName.contains("Titanium")) {
+                                RenderUtils.renderWayPoint(EnumChatFormatting.WHITE + entry.getKey(), entry.getValue(), event.partialTicks);
                             } else {
-                                RenderUtils.renderWayPoint(EnumChatFormatting.AQUA+entry.getKey(), entry.getValue(), event.partialTicks);
+                                RenderUtils.renderWayPoint(EnumChatFormatting.AQUA + entry.getKey(), entry.getValue(), event.partialTicks);
                             }
                         }
                     }

--- a/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Mining.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/options/seperateSections/Mining.java
@@ -31,6 +31,16 @@ public class Mining {
 
     @Expose
     @ConfigOption(
+            name = "Hide waypoints when at Location",
+            desc = "Hides the Commission Waypoints if you are already at the location of the waypoint.\n" +
+                    "Only active if Waypoints are set to \"Commissions Only\""
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 0)
+    public boolean hideWaypointIfAtLocation = true;
+
+    @Expose
+    @ConfigOption(
             name = "Emissary Waypoints",
             desc = "Show waypoints in the Dwarven mines to emissaries\n" +
                     "Use \"Commission End\" to only show after finishing commissions"


### PR DESCRIPTION
(For the Dwarven Mines Commission Waypoints)
If the Waypoints are set to Commission only this option will hide them if you are in that Location. 

For example if I have a Commission in Upper Mines and go there, the Waypoint will no longer render but when I leave it will show again.